### PR TITLE
Add ninja to Windows setup scripts

### DIFF
--- a/setup-bitnet.ps1
+++ b/setup-bitnet.ps1
@@ -16,7 +16,7 @@ function Round1 {
         Set-ExecutionPolicy Bypass -Scope Process -Force
         powershell -NoProfile -ExecutionPolicy Bypass -Command "iwr https://community.chocolatey.org/install.ps1 -UseBasicParsing | iex"
     }
-    choco install -y git python3 cmake llvm clang 7zip visualstudio2022buildtools
+    choco install -y git python3 cmake llvm clang ninja 7zip visualstudio2022buildtools
     choco install -y visualstudio2022buildtools --params "'/Quiet /Add Microsoft.VisualStudio.Workload.VCTools /Add Microsoft.VisualStudio.Component.VC.CMake.Project /Add Microsoft.VisualStudio.Component.VC.Llvm.Clang /Add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset /Add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset.MSBuild'"
     git --version; $gitStatus = $LASTEXITCODE
     python --version; $pythonStatus = $LASTEXITCODE

--- a/validate_installation.ps1
+++ b/validate_installation.ps1
@@ -1,4 +1,4 @@
-# Validate the installation of git, python, cmake, and clang
+# Validate the installation of git, python, cmake, clang, and ninja
 
 # Check git version
 git --version
@@ -16,8 +16,12 @@ $cmakeStatus = $LASTEXITCODE
 clang --version
 $clangStatus = $LASTEXITCODE
 
+# Check ninja version
+ninja --version
+$ninjaStatus = $LASTEXITCODE
+
 # Validate installation
-if ($gitStatus -eq 0 -and $pythonStatus -eq 0 -and $cmakeStatus -eq 0 -and $clangStatus -eq 0) {
+if ($gitStatus -eq 0 -and $pythonStatus -eq 0 -and $cmakeStatus -eq 0 -and $clangStatus -eq 0 -and $ninjaStatus -eq 0) {
     Write-Output "✅ ROUND 1 PASS"
 } else {
     Write-Output "❌ ROUND 1 FAIL"


### PR DESCRIPTION
## Summary
- install `ninja` via Chocolatey during setup
- verify `ninja --version` in installation validation script

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*