### PR TITLE
Fix Bitnet source list

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(GGML_HEADERS_BITNET ../include/ggml-bitnet.h)
-set(GGML_SOURCES_BITNET ggml-bitnet-mad.cpp)
-set(GGML_SOURCES_BITNET ggml-bitnet-lut.cpp)
+set(GGML_SOURCES_BITNET
+    ggml-bitnet-mad.cpp
+    ggml-bitnet-lut.cpp)
 
 include_directories(3rdparty/llama.cpp/ggml/include)
 


### PR DESCRIPTION
## Summary
- fix CMake list to include both `ggml-bitnet-mad.cpp` and `ggml-bitnet-lut.cpp`

## Testing
- `python -m unittest discover -s tests`