### PR TITLE
Update default model path for inference

### DIFF
--- a/run_inference.py
+++ b/run_inference.py
@@ -44,7 +44,14 @@ if __name__ == "__main__":
     signal.signal(signal.SIGINT, signal_handler)
     # Usage: python run_inference.py -p "Microsoft Corporation is an American multinational corporation and technology company headquartered in Redmond, Washington."
     parser = argparse.ArgumentParser(description='Run inference')
-    parser.add_argument("-m", "--model", type=str, help="Path to model file", required=False, default="models/bitnet_b1_58-3B/ggml-model-i2_s.gguf")
+    parser.add_argument(
+        "-m",
+        "--model",
+        type=str,
+        help="Path to model file (default: models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf)",
+        required=False,
+        default="models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf",
+    )
     parser.add_argument("-n", "--n-predict", type=int, help="Number of tokens to predict when generating text", required=False, default=128)
     parser.add_argument("-p", "--prompt", type=str, help="Prompt to generate text from", required=True)
     parser.add_argument("-t", "--threads", type=int, help="Number of threads to use", required=False, default=2)

--- a/run_inference_server.py
+++ b/run_inference_server.py
@@ -51,7 +51,14 @@ if __name__ == "__main__":
     signal.signal(signal.SIGINT, signal_handler)
     
     parser = argparse.ArgumentParser(description='Run llama.cpp server')
-    parser.add_argument("-m", "--model", type=str, help="Path to model file", required=False, default="models/bitnet_b1_58-3B/ggml-model-i2_s.gguf")
+    parser.add_argument(
+        "-m",
+        "--model",
+        type=str,
+        help="Path to model file (default: models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf)",
+        required=False,
+        default="models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf",
+    )
     parser.add_argument("-p", "--prompt", type=str, help="System prompt for the model", required=False)
     parser.add_argument("-n", "--n-predict", type=int, help="Number of tokens to predict", required=False, default=4096)
     parser.add_argument("-t", "--threads", type=int, help="Number of threads to use", required=False, default=2)


### PR DESCRIPTION
## Summary
- point inference scripts to the BitNet 2B model

## Testing
- `python -m py_compile run_inference.py run_inference_server.py`
- `python -m pytest -q` *(fails: No module named pytest)*