### PR TITLE
Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ This project is based on the [llama.cpp](https://github.com/ggerganov/llama.cpp)
 
 1. Clone the repo
 ```bash
-git clone --recursive https://github.com/microsoft/BitNet.git
-cd BitNet
+git clone --recursive https://github.com/darbotlabs/DarbotNet.git
+cd DarbotNet
 ```
 2. Install the dependencies
 ```bash
@@ -178,7 +178,7 @@ pip install -r requirements.txt
 3. Build the project
 ```bash
 # Manually download the model and run with local path
-huggingface-cli download microsoft/BitNet-b1.58-2B-4T-gguf --local-dir models/BitNet-b1.58-2B-4T
+huggingface-cli download darbotlabs/DarbotNet-b1.58-2B-4T-gguf --local-dir models/BitNet-b1.58-2B-4T
 python setup_env.py -md models/BitNet-b1.58-2B-4T -q i2_s
 
 ```
@@ -204,7 +204,7 @@ optional arguments:
 
 ### Quick start setup
 
-Open **PowerShell as Administrator** and run the all-in-one script to install
+Open **PowerShell as Administrator** in the root of this repository and run the all-in-one script to install
 the toolchain, set up the Python environment and fetch a model. The script
 prints the result of each stage and logs everything to `setup-log.txt`.
 


### PR DESCRIPTION
## Summary
- mention the darbotlabs repo when cloning
- fix the example HF download URL in the build instructions
- clarify that `setup-bitnet.ps1` can be run from the repo root

## Testing
- `pytest -q` *(fails: command not found)*
- `python -m unittest discover -v`